### PR TITLE
use export statement

### DIFF
--- a/src/drawim.nim
+++ b/src/drawim.nim
@@ -7,70 +7,16 @@ when defined(js):
 
 include drawim/constants/keycodes
 
-type ColorMode* = colors.ColorMode
-type ArcMode* = shapes.ArcMode
-
 var height* = 0
 var width* = 0
 var frameCount* = 0
 var time, deltaTime*: float = 0.0
 
-proc background*(rh, gs, bv: int|float) = colors.background(rh, gs, bv)
-proc background*(gray: int|float) = colors.background(gray)
+export colors, shapes, inputs
+export transform except resetTransform, getScreenPosition, getRealPosition
 
-proc stroke*(rh, gs, bv: int|float) = colors.stroke(rh, gs, bv)
-proc stroke*(rh, gs, bv, a: int|float) = colors.stroke(rh, gs, bv, a)
-proc stroke*(gray: int|float) = colors.stroke(gray)
-proc stroke*(hex: string) = colors.stroke(hex)
 proc noStroke*() = colors.stroke(0, 0, 0, 0)
-
-proc fill*(rh, gs, bv: int|float) = colors.fill(rh, gs, bv)
-proc fill*(rh, gs, bv, a: int|float) = colors.fill(rh, gs, bv, a)
-proc fill*(gray: int|float) = colors.fill(gray)
-proc fill*(hex: string) = colors.fill(hex)
 proc noFill*() = colors.fill(0, 0, 0, 0)
-
-proc setColorMode*(mode: ColorMode) = colors.setColorMode(mode)
-
-proc rotate*(theta: int|float) = transform.rotate(theta)
-proc translate*(x, y: int|float) = transform.translate(x, y)
-proc scale*(x, y: int|float) = transform.scale(x, y)
-proc push*() = transform.push()
-proc pop*() = transform.pop()
-
-proc beginPath*() = shapes.beginPath()
-proc beginShape*() = shapes.beginShape()
-proc beginFilledShape*() = shapes.beginFilledShape()
-proc endPath*() = shapes.endPath()
-proc endShape*() = shapes.endShape()
-proc endFilledShape*() = shapes.endFilledShape()
-proc vertex*(x, y: int|float) = shapes.vertex(x, y)
-
-proc beginPixels*() = shapes.beginPixels()
-proc endPixels*() = shapes.endPixels()
-proc setPixel*(x, y: int|float) = shapes.setPixel(x, y)
-
-proc rect*(x, y, w, h: int|float) = shapes.rect(x, y, w, h)
-proc rectFill*(x, y, w, h: int|float) = shapes.rectFill(x, y, w, h)
-proc triangle*(x1, y1, x2, y2, x3, y3: int|float) = shapes.triangle(x1, y1, x2,
-    y2, x3, y3)
-proc triangleFill*(x1, y1, x2, y2, x3, y3: int|float) = shapes.triangleFill(x1,
-    y1, x2, y2, x3, y3)
-proc arc*(cx, cy, rx, ry: int|float, beginAngle, endAngle: float,
-    mode: ArcMode = Open) = shapes.arc(cx, cy, rx, ry, beginAngle, endAngle, mode)
-proc arcFill*(cx, cy, rx, ry: int|float, beginAngle, endAngle: float,
-    mode: ArcMode = Open) = shapes.arcFill(cx, cy, rx, ry, beginAngle, endAngle, mode)
-proc ellipse*(cx, cy, rx, ry: int|float) = shapes.ellipse(cx, cy, rx, ry)
-proc ellipseFill*(cx, cy, rx, ry: int|float) = shapes.ellipseFill(cx, cy, rx, ry)
-proc circle*(cx, cy, r: int|float) = shapes.circle(cx, cy, r)
-proc circleFill*(cx, cy, r: int|float) = shapes.circleFill(cx, cy, r)
-proc line*(x1, y1, x2, y2: int|float) = shapes.line(x1, y1, x2, y2)
-proc bezier*(x1, y1, x2, y2, x3, y3, x4, y4: int|float) = shapes.bezier(x1, y1, x2, y2, x3, y3, x4, y4)
-
-proc mouseX*(): int = inputs.mouseX()
-proc mouseY*(): int = inputs.mouseY()
-proc isKeyPressed*(key: int): bool = inputs.isKeyPressed(key)
-proc isMousePressed*(btn: int): bool = inputs.isMousePressed(btn)
 
 proc drawWrapper(draw: proc()): proc() =
   return proc() =


### PR DESCRIPTION
remove the need for re declaring every symbol. alternatively it can be written more verbose:

```nim
#export
  #colors.ColorMode, colors.background, colors.stroke, colors.fill,
  #colors.setColorMode,
  #transform.rotate, transform.translate, transform.scale, transform.push,
  #transform.pop,
  #shapes.ArcMode, shapes.beginPath, shapes.beginShape, shapes.beginFilledShape,
  #shapes.endPath, shapes.endShape, shapes.endFilledShape, shapes.vertex,
  #shapes.beginPixels, shapes.endPixels, shapes.setPixel, shapes.rect,
  #shapes.rectFill, shapes.triangle, shapes.triangleFill, shapes.arc,
  #shapes.arcFill, shapes.ellipse, shapes.ellipseFill, shapes.circle,
  #shapes.circleFill, shapes.line, shapes.bezier,
  #inputs.mouseX, inputs.mouseY, inputs.isKeyPressed, inputs.isMousePressed
```

but seemed unnecessary. Private procs are not exported (resetTransform, getScreenPosition, getRealPosition).
noFill, noStroke could be moved in drawim/colors